### PR TITLE
[invalid]Changed Localize attribute prefix to 'attr-localize'

### DIFF
--- a/src/Localization.AspNetCore.TagHelpers/LocalizeAttributeTagHelper.cs
+++ b/src/Localization.AspNetCore.TagHelpers/LocalizeAttributeTagHelper.cs
@@ -31,8 +31,8 @@ namespace Localization.AspNetCore.TagHelpers
   [HtmlTargetElement(Attributes = LOCALIZE_ATTRIBUTE_PREFIX + "*")]
   public class LocalizeAttributeTagHelper : TagHelper
   {
-    private const string LOCALIZE_ATTRIBUTE_PREFIX = "localize-";
-    private const string LOCALIZE_DICTIONARY_NAME = "localize-all";
+    private const string LOCALIZE_ATTRIBUTE_PREFIX = "localize-attr-";
+    private const string LOCALIZE_DICTIONARY_NAME = "localize-attr-all";
     private readonly string applicationName;
     private readonly IHtmlLocalizerFactory localizerFactory;
     private IDictionary<string, string> attributeValues;

--- a/src/Localization.Demo/Localization/Views/Shared/Error.en.resx
+++ b/src/Localization.Demo/Localization/Views/Shared/Error.en.resx
@@ -117,8 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="&lt;strong&gt;Development environment should not be enabled in deployed applications&lt;/strong&gt;, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the &lt;strong&gt;ASPNETCORE_ENVIRONMENT&lt;/strong&gt; environment variable to &lt;strong&gt;Development&lt;/strong&gt;, and restarting the application." xml:space="preserve">
-    <value>&lt;strong&gt;Development environment should not be enabled in deployed applications&lt;/strong&gt;, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the &lt;strong&gt;ASPNETCORE_ENVIRONMENT&lt;/strong&gt; environment variable to &lt;strong&gt;Development&lt;/strong&gt;, and restarting the application.</value>
+  <data name="&lt;p&gt;&#xD;&#xA;    &lt;strong&gt;Development environment should not be enabled in deployed applications&lt;/strong&gt;, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the &lt;strong&gt;ASPNETCORE_ENVIRONMENT&lt;/strong&gt; environment variable to &lt;strong&gt;Development&lt;/strong&gt;, and restarting the application.&#xD;&#xA;  &lt;/p&gt;" xml:space="preserve">
+    <value>&lt;p&gt;
+    &lt;strong&gt;Development environment should not be enabled in deployed applications&lt;/strong&gt;, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the &lt;strong&gt;ASPNETCORE_ENVIRONMENT&lt;/strong&gt; environment variable to &lt;strong&gt;Development&lt;/strong&gt;, and restarting the application.
+  &lt;/p&gt;</value>
   </data>
   <data name="An error occurred while processing your request." xml:space="preserve">
     <value>An error occurred while processing your request.</value>

--- a/src/Localization.Demo/Localization/Views/Shared/Error.nb.resx
+++ b/src/Localization.Demo/Localization/Views/Shared/Error.nb.resx
@@ -117,8 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="&lt;strong&gt;Development environment should not be enabled in deployed applications&lt;/strong&gt;, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the &lt;strong&gt;ASPNETCORE_ENVIRONMENT&lt;/strong&gt; environment variable to &lt;strong&gt;Development&lt;/strong&gt;, and restarting the application." xml:space="preserve">
-    <value>&lt;strong&gt;Utvilingsmiljø bør ikke være aktivert i distribuerte applikasjoner&lt;/strong&gt;, ettersom det kan føre til sensitive informasjon fra unntakene som vises til sluttbrukere. For lokal debugging, kan utviklingsmiljø aktiveres ved å sette &lt;strong&gt;ASPNETCORE_ENVIRONMENT&lt;/strong&gt; miljøvariabelen til Development, og starte programmet på nytt.</value>
+  <data name="&lt;p&gt;&#xD;&#xA;    &lt;strong&gt;Development environment should not be enabled in deployed applications&lt;/strong&gt;, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the &lt;strong&gt;ASPNETCORE_ENVIRONMENT&lt;/strong&gt; environment variable to &lt;strong&gt;Development&lt;/strong&gt;, and restarting the application.&#xD;&#xA;  &lt;/p&gt;" xml:space="preserve">
+    <value>&lt;p&gt;
+  &lt;strong&gt;Utvilingsmiljø bør ikke være aktivert i distribuerte applikasjoner&lt;/strong&gt;, ettersom det kan føre til sensitive informasjon fra unntakene som vises til sluttbrukere. For lokal debugging, kan utviklingsmiljø aktiveres ved å sette &lt;strong&gt;ASPNETCORE_ENVIRONMENT&lt;/strong&gt; miljøvariabelen til Development, og starte programmet på nytt.
+&lt;/p&gt;</value>
   </data>
   <data name="An error occurred while processing your request." xml:space="preserve">
     <value>Det oppstod en feil under behandling av forespørselen.</value>

--- a/src/Localization.Demo/Views/Home/Contact.cshtml
+++ b/src/Localization.Demo/Views/Home/Contact.cshtml
@@ -10,7 +10,7 @@
   <parameter localize="">P:</parameter>
   {0}<br />
   {1}<br />
-  <abbr localize-title="Phone">{2}</abbr>
+  <abbr localize-attr-title="Phone">{2}</abbr>
   425.555.0100
 </address>
 

--- a/src/Localization.Demo/Views/Home/Index.cshtml
+++ b/src/Localization.Demo/Views/Home/Index.cshtml
@@ -11,7 +11,7 @@
   </ol>
   <div class="carousel-inner" role="listbox">
     <div class="item active">
-      <img src="~/images/banner1.svg" localize-alt="ASP.NET" class="img-responsive" />
+      <img src="~/images/banner1.svg" localize-attr-alt="ASP.NET" class="img-responsive" />
       <div class="carousel-caption" role="option">
         <p>
           <localize>Learn how to build ASP.NET apps that can run anywhere.</localize>
@@ -22,7 +22,7 @@
       </div>
     </div>
     <div class="item">
-      <img src="~/images/banner2.svg" localize-alt="Visual Studio" class="img-responsive" />
+      <img src="~/images/banner2.svg" localize-attr-alt="Visual Studio" class="img-responsive" />
       <div class="carousel-caption" role="option">
         <p>
           <localize>There are powerful new features in Visual Studio for building modern web apps.</localize>
@@ -33,7 +33,7 @@
       </div>
     </div>
     <div class="item">
-      <img src="~/images/banner3.svg" localize-alt="Package Management" class="img-responsive" />
+      <img src="~/images/banner3.svg" localize-attr-alt="Package Management" class="img-responsive" />
       <div class="carousel-caption" role="option">
         <p>
           <localize>Bring in libraries from NuGet, Bower, and npm, and automate tasks using Grunt or Gulp.</localize>
@@ -44,7 +44,7 @@
       </div>
     </div>
     <div class="item">
-      <img src="~/images/banner4.svg" localize-alt="Microsoft Azure" class="img-responsive" />
+      <img src="~/images/banner4.svg" localize-attr-alt="Microsoft Azure" class="img-responsive" />
       <div class="carousel-caption" role="option">
         <p>
           <localize>Learn how Microsoft's Azure cloud platform allows you to build, deploy, and scale web apps.</localize>


### PR DESCRIPTION
This unfortunately breaks the previously released version

This change was reverted back to its origin, rename changes in GenericLocalizeTagHelper was applied instead.
see #10 
