### PR TITLE
Cache IHtmlLocalizer instances

### DIFF
--- a/docs/input/docs/helpers/content-tag-localization.md
+++ b/docs/input/docs/helpers/content-tag-localization.md
@@ -105,5 +105,4 @@ localizer by passing it for every call to the localize tag helper.
 </localize>
 ```
 
-***NOTE: There is a wish to have this automatically detected, but no such luck for this have been found yet.
-Any help for this would be appreciated.***
+***NOTE: The tag helpers now cache IHTMLLocalizer instances, you don't have to explicitly cache them anymore.***

--- a/src/Localization.AspNetCore.TagHelpers/GenericLocalizeTagHelper.cs
+++ b/src/Localization.AspNetCore.TagHelpers/GenericLocalizeTagHelper.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="GenericLocalizeTagHelper.cs">
 //   Copyright (c) Kim Nordmo. All rights reserved.
 //   Licensed under the MIT license. See LICENSE file in the project root for full license information.
@@ -46,6 +46,7 @@ namespace Localization.AspNetCore.TagHelpers
     private const string LOCALIZE_TRIM = "trim";
     private const string LOCALIZE_TRIM_LINES = "trimlines";
     private const string LOCALIZE_TYPE = "resource-type";
+    private const string CACHED_LOCALIZER_KEY = "CachedLocalizerFor";
     private readonly string applicationName;
     private readonly IHtmlLocalizerFactory localizerFactory;
 
@@ -193,7 +194,20 @@ namespace Localization.AspNetCore.TagHelpers
     /// <inheritdoc/>
     public override void Init(TagHelperContext context)
     {
-      Localizer = Localizer ?? localizerFactory.ResolveLocalizer(ViewContext, applicationName, Type, Name);
+      var key = CACHED_LOCALIZER_KEY + ViewContext.ExecutingFilePath;
+
+      if (Localizer is null)
+      {
+        if (ViewContext.ViewData.ContainsKey(key))
+        {
+          Localizer = ViewContext.ViewData[key] as IHtmlLocalizer;
+        }
+        else
+        {
+          Localizer = localizerFactory.ResolveLocalizer(ViewContext, applicationName, Type, Name);
+          ViewContext.ViewData[key] = Localizer;
+        }
+      }
 
       if (!SupportsParameters)
       {

--- a/test/Localization.AspNetCore.TagHelpers.Tests/GenericLocalizeTagHelperTests.cs
+++ b/test/Localization.AspNetCore.TagHelpers.Tests/GenericLocalizeTagHelperTests.cs
@@ -214,10 +214,6 @@ namespace Localization.AspNetCore.TagHelpers.Tests
       var tagHelper = TestHelper.CreateTagHelper<GenericLocalizeTagHelper>(factoryMock.Object);
       var tagContext = TestHelper.CreateTagContext();
 
-      // It seems that the tests are not run independently, See #26
-      tagHelper.ViewContext = new ViewContext { ExecutingFilePath = "View1" };
-      tagHelper.Localizer = null;
-
       tagHelper.Init(tagContext);
       tagHelper.Init(tagContext);
 
@@ -349,7 +345,7 @@ namespace Localization.AspNetCore.TagHelpers.Tests
       var options = Options.Create(new LocalizeTagHelperOptions { HtmlEncodeByDefault = false, NewLineHandling = NewLineHandling.None, TrimWhitespace = false });
       var helper = new GenericLocalizeTagHelper(factory.Object, hostingEnvMock.Object, options)
       {
-        ViewContext = TestHelper.DefaultViewContext
+        ViewContext = TestHelper.CreateViewContext()
       };
       var result = await TestHelper.GenerateHtmlAsync(helper, "p", expected);
 

--- a/test/Localization.AspNetCore.TagHelpers.Tests/TestHelper.cs
+++ b/test/Localization.AspNetCore.TagHelpers.Tests/TestHelper.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="TestHelper.cs">
 //   Copyright (c) Kim Nordmo. All rights reserved.
 //   Licensed under the MIT license. See LICENSE file in the project root for full license information.
@@ -27,13 +27,14 @@ namespace Localization.AspNetCore.TagHelpers.Tests
   {
     public static readonly string ApplicationName = typeof(TestHelper).GetTypeInfo().Assembly.GetName().Name;
 
-    public static readonly ViewContext DefaultViewContext = new ViewContext();
-
-    static TestHelper()
+    public static ViewContext CreateViewContext()
     {
       var view = new Mock<IView>();
       view.SetupGet(x => x.Path).Returns("some/value.cshtml");
-      DefaultViewContext.View = view.Object;
+      var context = new ViewContext();
+      context.View = view.Object;
+
+      return context;
     }
 
     public static Mock<IHtmlLocalizerFactory> CreateFactoryMock(bool setup)
@@ -85,7 +86,7 @@ namespace Localization.AspNetCore.TagHelpers.Tests
       }
 
       var instance = (T)Activator.CreateInstance(typeof(T), factory, hostingEnvironmentMock.Object, null);
-      instance.ViewContext = DefaultViewContext;
+      instance.ViewContext = CreateViewContext();
       instance.NewLineHandling = NewLineHandling.None;
 
       return instance;


### PR DESCRIPTION
Changed GenericLocalizeTagHelper so that it doesn't create new IHtmlLocalizer instances everytime `Init` is called.

## Description
`Init` now checks whether `Localizer` is null (not supplied by the user). If that's the case, then it checks to see if a previous `GenericLocalizeTagHelper` in the same view file has created an `IHtmlLocalizer` by searching in `ViewContext.ViewData`:
 - Yes => The cached Localizer is used
 - No => A new instance of `IHtmlLocalizer` is requested and is cached in `ViewContext.ViewData`.

## Related Issue
#25 

## Motivation and Context
Makes the tag helpers faster.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
